### PR TITLE
Fixes #3 specify Ruby version in gemspec

### DIFF
--- a/emque-web.gemspec
+++ b/emque-web.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = "~> 2.1.2"
 
   spec.add_dependency "oj",      "~> 2.11.4"
   spec.add_dependency "faraday", "~> 0.9"


### PR DESCRIPTION
Include a ruby version requirement, similar to emque-consuming's version since this is talking to that.